### PR TITLE
Add drush command for restoring db, seems to work without 'errors' 

### DIFF
--- a/src/Drush.php
+++ b/src/Drush.php
@@ -20,7 +20,7 @@ class Drush
     {
         $cwd = getcwd();
         chdir('/opt/app-root/src');
-        SysCmd::exec(sprintf('vendor/bin/drush --debug sql:query --file=%s 2>&1',
+        SysCmd::exec(sprintf('vendor/bin/drush sql:query --file=%s 2>&1',
           $pathToDump . '/database.tar'
         ), '/opt/app-root/src', TRUE, TRUE);
         chdir($cwd);

--- a/src/Drush.php
+++ b/src/Drush.php
@@ -15,4 +15,15 @@ class Drush
         chdir($cwd);
         return $json;
     }
+
+    public function sqlRestore($pathToDump)
+    {
+        $cwd = getcwd();
+        chdir('/opt/app-root/src');
+        SysCmd::exec(sprintf('vendor/bin/drush --debug sql:query --file=%s 2>&1',
+          $pathToDump . '/database.tar'
+        ), '/opt/app-root/src', TRUE, TRUE);
+        chdir($cwd);
+        return TRUE;
+    }
 }

--- a/src/Postgres.php
+++ b/src/Postgres.php
@@ -54,21 +54,20 @@ class Postgres
         $this->createPassFile($db);
 
         try {
-/*            SysCmd::exec(sprintf('pg_restore --no-privileges --no-owner -h %s -p %s -U %s -d %s %s 2>&1',
+           if ($site->siteType == 'drupal') {
+             $drush = new Drush();
+             $drush->sqlRestore($site->cfg['tmpdir']);
+           }
+           else {
+             SysCmd::exec(sprintf('pg_restore --no-privileges --no-owner -h %s -p %s -U %s -d %s %s 2>&1',
                 $db['host'],
                 $db['port'],
                 $db['user'],
                 $db['name'],
-                $db['file']
-            ), $site->cfg['tmpdir'], FALSE, TRUE);*/
-
-            SysCmd::exec(sprintf('psql -q --dbname=%s --host=%s --port=%s --username=%s  --no-align --field-separator="    " --pset tuples_only=on --file %s 2>&1',
-                $db['name'],
-                $db['host'],
-                $db['port'],
-                $db['user'],
                 $db['file']
             ), $site->cfg['tmpdir'], FALSE, TRUE);
+           }
+
         }
         catch (\Exception $e) {
             Log::error("Error running the restore command: " . $e->getMessage());

--- a/src/Postgres.php
+++ b/src/Postgres.php
@@ -25,7 +25,7 @@ class Postgres
 
         // Dump database using tar format (-F t).
         try {
-            SysCmd::exec(sprintf('pg_dump -h %s -p %s -U %s -x -c -F t %s > %s 2>&1',
+            SysCmd::exec(sprintf('pg_dump -h %s -p %s -U %s -x -c %s > %s 2>&1',
                 $db['host'],
                 $db['port'],
                 $db['user'],
@@ -54,15 +54,24 @@ class Postgres
         $this->createPassFile($db);
 
         try {
-            SysCmd::exec(sprintf('pg_restore --no-privileges --no-owner -h %s -p %s -U %s -d %s -F t %s 2>&1',
+/*            SysCmd::exec(sprintf('pg_restore --no-privileges --no-owner -h %s -p %s -U %s -d %s %s 2>&1',
                 $db['host'],
                 $db['port'],
                 $db['user'],
                 $db['name'],
                 $db['file']
+            ), $site->cfg['tmpdir'], FALSE, TRUE);*/
+
+            SysCmd::exec(sprintf('psql -q --dbname=%s --host=%s --port=%s --username=%s  --no-align --field-separator="    " --pset tuples_only=on --file %s 2>&1',
+                $db['name'],
+                $db['host'],
+                $db['port'],
+                $db['user'],
+                $db['file']
             ), $site->cfg['tmpdir'], FALSE, TRUE);
         }
         catch (\Exception $e) {
+            Log::error("Error running the restore command: " . $e->getMessage());
         }
 
         $this->removePassFile();


### PR DESCRIPTION
I tested this to restore using 'drush' which is reloads the db using a wrapper of psql (and without 'errors') however not sure if that means there aren't any.  pg_restore threw lots of error messages.
